### PR TITLE
fix: resolve padLevels circular dependency warning and modernise code…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,77 @@
 #! /usr/bin/env node
 
-var exec = require('child_process').exec;
-var ADB = require('appium-adb');
-var adb = new ADB();
-var args = process.argv.slice(2).join(' ');
+// Suppress harmless npmlog@5 circular-dependency warning (transitive via appium-adb).
+// Must run before requiring appium-adb. Lets every other warning through.
+const _emit = process.emit;
+process.emit = function (name, data, ...rest) {
+  if (
+    name === 'warning' &&
+    data &&
+    data.name === 'Warning' &&
+    /padLevels/.test(data.message)
+  ) {
+    return false;
+  }
+  return _emit.call(this, name, data, ...rest);
+};
 
-adb.getConnectedDevices(function(err, devices) {
-  if (err) {
-    console.log(err);
-    process.exit(1);
+const { spawn } = require('child_process');
+const { ADB } = require('appium-adb');
+
+// Run `adb -s <udid> <args>` and resolve when it exits.
+function runOnDevice(adbPath, udid, args, interactive) {
+  return new Promise((resolve) => {
+    const argv = ['-s', udid, ...args];
+    if (interactive) {
+      // Single device: attach device TTY directly (real interactive shell).
+      const child = spawn(adbPath, argv, { stdio: 'inherit' });
+      child.on('close', resolve);
+      child.on('error', (err) => {
+        console.log('error for device:', udid, err);
+        resolve();
+      });
+    } else {
+      // Multiple devices: buffer and label output per device.
+      const child = spawn(adbPath, argv);
+      let out = '';
+      child.stdout.on('data', (d) => (out += d));
+      child.stderr.on('data', (d) => (out += d));
+      child.on('close', () => {
+        console.log(udid, ':', out.trim());
+        resolve();
+      });
+      child.on('error', (err) => {
+        console.log('error for device:', udid, err);
+        resolve();
+      });
+    }
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const adb = await ADB.createADB();
+  const devices = await adb.getConnectedDevices();
+
+  if (devices.length === 0) {
+    console.log('No connected devices.');
+    return;
   }
 
-  devices.forEach(function(device){
-    var arg = "adb -s " + device.udid + " " + args;
-    exec(arg, function(err, stdout, stderr){
-      if (err) { console.log ('error for device:', device.udid, err); }
-      console.log(device.udid, ':', stdout, stderr || '');
-    });
-  });
+  const adbPath = adb.executable.path;
+  // Interactive (inherit stdio) only makes sense with a single device.
+  const interactive = devices.length === 1;
+
+  if (interactive) {
+    await runOnDevice(adbPath, devices[0].udid, args, true);
+  } else {
+    await Promise.all(
+      devices.map((d) => runOnDevice(adbPath, d.udid, args, false))
+    );
+  }
+}
+
+main().catch((err) => {
+  console.log(err);
+  process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adb-foreach",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Commandline tool to send commands to all Android devices currently connected to your machine",
   "main": "index.js",
   "bin": "index.js",
@@ -12,6 +12,8 @@
     "devices"
   ],
   "dependencies": {
-    "appium-adb": "^1.3.16"
+    "adb-foreach": "file:adb-foreach-1.0.2.tgz",
+    "appium-adb": "^9.0.0",
+    "process": "^0.11.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "adb-foreach",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Commandline tool to send commands to all Android devices currently connected to your machine",
   "main": "index.js",
   "bin": "index.js",
-  "author": "jonahss",
+  "author": "Jonahss",
   "license": "apache-2.0",
   "keywords": [
     "android",
@@ -12,7 +12,6 @@
     "devices"
   ],
   "dependencies": {
-    "adb-foreach": "file:adb-foreach-1.0.2.tgz",
     "appium-adb": "^9.0.0",
     "process": "^0.11.10"
   }


### PR DESCRIPTION
Fixes the following warning that appears on Node.js 16+ due to a circular dependency in npmlog (a transitive dependency of appium-adb):
(node:XXXX) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
Changes

Suppressed the padLevels circular dependency warning by patching process.emit before appium-adb is loaded. All other warnings are passed through unaffected.
Modernised the codebase from callbacks to async/await
Replaced exec with spawn for better output streaming
Added interactive mode: single device gets a real TTY (useful for adb shell), multiple devices get labelled output per device
Updated appium-adb from ^1.3.16 to ^9.0.0

Tested with

Node.js 18
Multiple connected Android devices via USB